### PR TITLE
Fix: Correct DimensionHelper imports and usage

### DIFF
--- a/app/(drawer)/donation.tsx
+++ b/app/(drawer)/donation.tsx
@@ -7,7 +7,7 @@ import { MainHeader } from '@/src/components/wrapper/MainHeader';
 import { ApiHelper, CacheHelper, UserHelper, globalStyles } from '@/src/helpers';
 import { ErrorHelper } from '@/src/helpers/ErrorHelper';
 import { NavigationProps, StripePaymentMethod } from '@/src/interfaces';
-import { DimensionHelper } from '@churchapps/mobilehelper';
+import { DimensionHelper } from '@/src/helpers/DimensionHelper';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { useIsFocused } from '@react-navigation/native';
 import { initStripe } from "@stripe/stripe-react-native";
@@ -74,7 +74,7 @@ const Donation = (props: Props) => {
         }
         <DonationForm paymentMethods={paymentMethods} customerId={customerId} updatedFunction={loadData} />
         {!UserHelper.currentUserChurch?.person?.id
-          ? <Text style={[globalStyles.paymentDetailText, { marginVertical: DimensionHelper.wp('2%'), }]}>Please login to view existing donations</Text>
+          ? <Text style={[globalStyles.paymentDetailText, { marginVertical: DimensionHelper.wp(2), }]}>Please login to view existing donations</Text>
           : <View>
             <RecurringDonations customerId={customerId} paymentMethods={paymentMethods} updatedFunction={loadData} />
             <Donations />

--- a/app/(drawer)/memberDetail.tsx
+++ b/app/(drawer)/memberDetail.tsx
@@ -3,7 +3,7 @@ import { Loader } from '@/src/components/Loader';
 import { MainHeader } from '@/src/components/wrapper/MainHeader';
 import { ApiHelper, Constants, EnvironmentHelper, UserHelper, globalStyles } from '@/src/helpers';
 import { NavigationProps } from '@/src/interfaces';
-import { DimensionHelper } from '@churchapps/mobilehelper';
+import { DimensionHelper } from '@/src/helpers/DimensionHelper';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome';
 import Icon from '@expo/vector-icons/Zocial';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -79,7 +79,7 @@ const MemberDetail = (props: Props) => {
 
   const renderMemberItem = (item: any) => {
     return (
-      <TouchableOpacity style={[globalStyles.listMainView, { width: DimensionHelper.wp('90%') }]} onPress={() => onMembersClick(item)}>
+      <TouchableOpacity style={[globalStyles.listMainView, { width: DimensionHelper.wp(90) }]} onPress={() => onMembersClick(item)}>
         <Image source={item.photo ? { uri: EnvironmentHelper.ContentRoot + item.photo } : Constants.Images.ic_member} style={globalStyles.memberListIcon} />
         <View style={globalStyles.listTextView}>
           <Text style={globalStyles.listTitleText} numberOfLines={1}>{item.name.display}</Text>
@@ -114,25 +114,25 @@ const MemberDetail = (props: Props) => {
           </TouchableOpacity>
         </View>
 
-        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp('90%') }]} onPress={() => onEmailClick(memberinfo.email)}>
+        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp(90) }]} onPress={() => onEmailClick(memberinfo.email)}>
           <View style={globalStyles.detailIconContainer}>
-            <Icon name={'email'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp('4.8%')} />
+            <Icon name={'email'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp(4.8)} />
             <Text style={globalStyles.detailHeader}>Email :</Text>
           </View>
           <Text style={globalStyles.detailValue}>{memberinfo.email ? memberinfo.email : '-'}</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp('90%') }]} onPress={() => onPhoneClick(memberinfo.homePhone)}>
+        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp(90) }]} onPress={() => onPhoneClick(memberinfo.homePhone)}>
           <View style={globalStyles.detailIconContainer}>
-            <FontAwesome5 name={'phone'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp('4.8%')} />
+            <FontAwesome5 name={'phone'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp(4.8)} />
             <Text style={globalStyles.detailHeader}>Phone :</Text>
           </View>
           <Text style={globalStyles.detailValue}>{memberinfo.homePhone ? memberinfo.homePhone : '-'}</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp('90%') }]} onPress={() => onAddressClick()}>
+        <TouchableOpacity style={[globalStyles.memberDetailContainer, { width: DimensionHelper.wp(90) }]} onPress={() => onAddressClick()}>
           <View style={globalStyles.detailIconContainer}>
-            <FontAwesome5 name={'location-arrow'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp('4.8%')} />
+            <FontAwesome5 name={'location-arrow'} color={Constants.Colors.app_color} style={globalStyles.detailIcon} size={DimensionHelper.wp(4.8)} />
             <Text style={globalStyles.detailHeader}>Address :</Text>
           </View>
           {memberinfo.address1 ? <Text style={globalStyles.detailValue}>{memberinfo.address1}</Text> : null}

--- a/app/(drawer)/membersSearch.tsx
+++ b/app/(drawer)/membersSearch.tsx
@@ -3,7 +3,7 @@ import { Loader } from '@/src/components/Loader';
 import { MainHeader } from '@/src/components/wrapper/MainHeader';
 import { ApiHelper, Constants, EnvironmentHelper, UserHelper, globalStyles } from '@/src/helpers';
 import { NavigationProps } from '@/src/interfaces';
-import { DimensionHelper } from '@churchapps/mobilehelper';
+import { DimensionHelper } from '@/src/helpers/DimensionHelper';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { router, useNavigation } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -47,7 +47,7 @@ const MembersSearch = (props: Props) => {
 
   const renderMemberItem = (item: any) => {
     return (
-      <TouchableOpacity style={[globalStyles.listMainView, { width: DimensionHelper.wp('90%') }]} onPress={() => {
+      <TouchableOpacity style={[globalStyles.listMainView, { width: DimensionHelper.wp(90) }]} onPress={() => {
 
 
         router.navigate({
@@ -79,13 +79,13 @@ const MembersSearch = (props: Props) => {
       <MainHeader title="Directory" openDrawer={navigation.openDrawer} back={navigation.goBack} />
       <View style={{ width: DimensionHelper.wp(100), flex: 1, alignItems: 'center', justifyContent: 'center' }}>
 
-        <Text style={[globalStyles.searchMainText, { marginHorizontal: DimensionHelper.wp('5%') }]}>Find Members</Text>
-        <View style={[globalStyles.textInputView, { width: DimensionHelper.wp('90%') }]}>
+        <Text style={[globalStyles.searchMainText, { marginHorizontal: DimensionHelper.wp(5) }]}>Find Members</Text>
+        <View style={[globalStyles.textInputView, { width: DimensionHelper.wp(90) }]}>
           <Image source={Constants.Images.ic_search} style={globalStyles.searchIcon} />
-          <TextInput style={[globalStyles.textInputStyle, { width: DimensionHelper.wp('90%') }]} placeholder={'Member Name'} autoCapitalize="none" autoCorrect={false} keyboardType='default' placeholderTextColor={'lightgray'} value={searchText} onChangeText={(text) => { setSearchText(text) }} />
+          <TextInput style={[globalStyles.textInputStyle, { width: DimensionHelper.wp(90) }]} placeholder={'Member Name'} autoCapitalize="none" autoCorrect={false} keyboardType='default' placeholderTextColor={'lightgray'} value={searchText} onChangeText={(text) => { setSearchText(text) }} />
 
         </View>
-        <TouchableOpacity style={[globalStyles.roundBlueButton, { marginTop: DimensionHelper.wp('6%'), width: DimensionHelper.wp('90%') }]} onPress={() => filterMember(searchText)}>
+        <TouchableOpacity style={[globalStyles.roundBlueButton, { marginTop: DimensionHelper.wp(6), width: DimensionHelper.wp(90) }]} onPress={() => filterMember(searchText)}>
           <Text style={globalStyles.roundBlueButtonText}>SEARCH</Text>
         </TouchableOpacity>
 

--- a/app/(drawer)/messageScreen.tsx
+++ b/app/(drawer)/messageScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DimensionHelper } from '@churchapps/mobilehelper';
+import { DimensionHelper } from '@/src/helpers/DimensionHelper';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { useEffect, useState } from 'react';
 
@@ -104,7 +104,7 @@ const MessageScreen = (props: Props) => {
   }
 
   const backIconComponent = (<TouchableOpacity onPress={() => router.navigate('/(drawer)/dashboard')}>
-    <Icon name={"keyboard-backspace"} style={globalStyles.menuIcon} color={"white"} size={DimensionHelper.wp('5%')} />
+    <Icon name={"keyboard-backspace"} style={globalStyles.menuIcon} color={"white"} size={DimensionHelper.wp(5)} />
   </TouchableOpacity>);
 
   //const mainComponent = (<Text style={globalStyles.headerText}>{props?.route?.params?.userDetails?.name?.display ? props?.route?.params?.userDetails?.name?.display : props?.route?.params?.userDetails?.DisplayName }</Text>);
@@ -124,25 +124,25 @@ const MessageScreen = (props: Props) => {
       }}
     />
     <TouchableOpacity style={globalStyles.sendIcon} onPress={() => sendMessageInitiate()}>
-      <MessageIcon name={"send"} color={"white"} size={DimensionHelper.wp('5%')} />
+      <MessageIcon name={"send"} color={"white"} size={DimensionHelper.wp(5)} />
     </TouchableOpacity>
   </View>);
 
 
   const messagesView = () => (<View style={{ flex: 1, backgroundColor: Constants.Colors.gray_bg }}>
-    <FlatList inverted data={messageList} style={{ paddingVertical: DimensionHelper.wp('2%') }} renderItem={({ item }) => singleMessageItem(item)} keyExtractor={(item: any) => item.id} />
+    <FlatList inverted data={messageList} style={{ paddingVertical: DimensionHelper.wp(2) }} renderItem={({ item }) => singleMessageItem(item)} keyExtractor={(item: any) => item.id} />
   </View>);
 
   const singleMessageItem = (item: MessageInterface) => (<TouchableWithoutFeedback onLongPress={() => openContextMenu(item)}>
     <View style={[globalStyles.messageContainer, { alignSelf: item.personId != details.id ? 'flex-end' : 'flex-start' }]}>
-      {item.personId == details.id ? <Image source={details?.photo ? { uri: EnvironmentHelper.ContentRoot + details?.photo } : Constants.Images.ic_user} style={[globalStyles.churchListIcon, { tintColor: details.photo ? '' : Constants.Colors.app_color, height: DimensionHelper.wp('9%'), width: DimensionHelper.wp('9%'), borderRadius: DimensionHelper.wp('9%') }]} /> : null}
+      {item.personId == details.id ? <Image source={details?.photo ? { uri: EnvironmentHelper.ContentRoot + details?.photo } : Constants.Images.ic_user} style={[globalStyles.churchListIcon, { tintColor: details.photo ? '' : Constants.Colors.app_color, height: DimensionHelper.wp(9), width: DimensionHelper.wp(9), borderRadius: DimensionHelper.wp(9) }]} /> : null}
       <View>
         <Text style={[globalStyles.senderNameText, { alignSelf: item.personId != details.id ? 'flex-end' : 'flex-start' }]}>{item.displayName}</Text>
-        <View style={[globalStyles.messageView, { width: item.content.length > 15 ? DimensionHelper.wp('65%') : DimensionHelper.wp((item.content.length + 14).toString() + "%"), alignSelf: item.personId != details.id ? 'flex-end' : 'flex-start' }]}>
+        <View style={[globalStyles.messageView, { width: item.content.length > 15 ? DimensionHelper.wp(65) : DimensionHelper.wp(item.content.length + 14), alignSelf: item.personId != details.id ? 'flex-end' : 'flex-start' }]}>
           <Text>{item.content}</Text>
         </View>
       </View>
-      {item.personId != details.id ? <Image source={UserProfilePic ? { uri: EnvironmentHelper.ContentRoot + UserProfilePic } : Constants.Images.ic_user} style={[globalStyles.churchListIcon, { tintColor: UserProfilePic ? '' : Constants.Colors.app_color, height: DimensionHelper.wp('9%'), width: DimensionHelper.wp('9%'), borderRadius: DimensionHelper.wp('9%') }]} /> : null}
+      {item.personId != details.id ? <Image source={UserProfilePic ? { uri: EnvironmentHelper.ContentRoot + UserProfilePic } : Constants.Images.ic_user} style={[globalStyles.churchListIcon, { tintColor: UserProfilePic ? '' : Constants.Colors.app_color, height: DimensionHelper.wp(9), width: DimensionHelper.wp(9), borderRadius: DimensionHelper.wp(9) }]} /> : null}
     </View>
   </TouchableWithoutFeedback>);
 


### PR DESCRIPTION
This commit addresses issues with DimensionHelper:

- Corrected import paths for DimensionHelper in multiple files to point to the local helper instead of an external package.
- Updated calls to DimensionHelper.wp and DimensionHelper.hp to use numeric arguments (e.g., `50`) instead of string percentage formats (e.g., `"50%"`).

Affected files:
- app/(drawer)/donation.tsx
- app/(drawer)/memberDetail.tsx
- app/(drawer)/membersSearch.tsx
- app/(drawer)/messageScreen.tsx