### PR TITLE
Fix: Bible crash in both iOS and android app

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -107,7 +107,7 @@ module.exports = {
       MEMBERSHIP_API: process.env.MEMBERSHIP_API || "https://api.churchapps.org/membership",
       MESSAGING_API: process.env.MESSAGING_API || "https://api.churchapps.org/messaging",
       STAGE: process.env.STAGE || "prod",
-      YOUVERSION_API_KEY: process.env.YOUVERSION_API_KEY,
+      YOUVERSION_API_KEY: process.env.YOUVERSION_API_KEY || "kcjG9986IOT5ThXvd3lJT1DArk9RBlYt6gzAVNA8Lnb9a8Ld",
       eas: {
         projectId: "f72e5911-b8d5-467c-ad9e-423c180e9938"
       }

--- a/app/(drawer)/bible.tsx
+++ b/app/(drawer)/bible.tsx
@@ -1,24 +1,26 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Platform } from "react-native";
 import { useThemeColors } from "@/theme";
 import { Text, Button } from "react-native-paper";
 import * as WebBrowser from "expo-web-browser";
+import { getYouVersionModule } from "@/helpers/YouVersionHelper";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const Bible = () => {
   const tc = useThemeColors();
+  const insets = useSafeAreaInsets();
 
-  let BibleReaderView: React.ComponentType<any> | null = null;
-  try {
-
-    BibleReaderView = require("@youversion/platform-react-native")?.BibleReaderView ?? null;
-  } catch {
-    BibleReaderView = null;
-  }
+  const BibleReaderView = getYouVersionModule()?.BibleReaderView ?? null;
+  const androidInsetCompensation = Platform.OS === "android"
+    ? { marginTop: -insets.top }
+    : null;
 
   return (
     <View style={[styles.container, { backgroundColor: tc.surface }]}>
       {BibleReaderView ? (
-        <BibleReaderView appName="B1 Church" signInMessage="Sign in with YouVersion to access your highlights and bookmarks" />
+        <View style={[styles.readerContainer, androidInsetCompensation]}>
+          <BibleReaderView appName="B1 Church" signInMessage="Sign in with YouVersion to access your highlights and bookmarks" />
+        </View>
       ) : (
         <View style={styles.fallback}>
           <Text variant="titleMedium" style={[styles.fallbackTitle, { color: tc.text }]}>
@@ -42,6 +44,7 @@ const Bible = () => {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
+  readerContainer: { flex: 1, overflow: "hidden" },
   fallback: { flex: 1, padding: 20, justifyContent: "center" },
   fallbackTitle: { marginBottom: 8, textAlign: "center" },
   fallbackBody: { marginBottom: 16, textAlign: "center" },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,6 +15,7 @@ import { HeaderBell } from "@/components/wrapper/HeaderBell";
 import { Platform, StatusBar } from "react-native";
 import { AppLifecycleManager } from "../src/helpers/AppLifecycleManager";
 import { useThemeColors } from "../src/theme";
+import { getYouVersionModule } from "../src/helpers/YouVersionHelper";
 import "../src/i18n";
 import * as Sentry from "@sentry/react-native";
 import Constants from "expo-constants";
@@ -26,19 +27,6 @@ function ThemedStatusBar() {
   const barStyle = tc.onPrimary.toLowerCase() === "#ffffff" ? "light-content" : "dark-content";
 
   return <StatusBar barStyle={barStyle} backgroundColor={tc.headerBg} />;
-}
-
-const youversionKey = Constants.expoConfig?.extra?.YOUVERSION_API_KEY;
-if (youversionKey) {
-  try {
-    // This package is optional / may not be linked in some builds.
-    // Avoid crashing the app if the native module isn't present.
-
-    const { YouVersionPlatform } = require("@youversion/platform-react-native");
-    YouVersionPlatform.configure(youversionKey);
-  } catch (error) {
-    console.warn("[YouVersion] Native module not available - skipping configuration.", error);
-  }
 }
 
 Sentry.init({
@@ -131,6 +119,18 @@ function ThemedStack() {
 function RootLayout() {
   useEffect(() => {
     const setupApp = async () => {
+      const youversionKey = Constants.expoConfig?.extra?.YOUVERSION_API_KEY;
+      if (youversionKey) {
+        const youVersionModule = getYouVersionModule();
+        if (youVersionModule?.YouVersionPlatform) {
+          youVersionModule.YouVersionPlatform.configure(youversionKey);
+        } else {
+          console.warn("[YouVersion] Native module not available - skipping configuration.");
+        }
+      } else {
+        console.warn("[YouVersion] Missing YOUVERSION_API_KEY - skipping configuration.");
+      }
+
       await initializeFirebase();
       await UserHelper.loadSecureTokens();
       await initializeQueryCache();

--- a/ios/B1Mobile.xcodeproj/project.pbxproj
+++ b/ios/B1Mobile.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripePayments/Stripe3DS2.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripePaymentsUI/StripePaymentsUIBundle.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/StripeUICore/StripeUICoreBundle.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/YouVersionPlatform/YouVersionPlatformResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-launcher/EXDevLauncher.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/EXDevMenu.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb_Privacy.bundle",
@@ -375,6 +376,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Stripe3DS2.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripePaymentsUIBundle.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/StripeUICoreBundle.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/YouVersionPlatformResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevLauncher.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXDevMenu.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/nanopb_Privacy.bundle",
@@ -412,7 +414,7 @@
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = B1Mobile/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -441,7 +443,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 59;
 				INFOPLIST_FILE = B1Mobile/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -508,7 +510,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -566,7 +568,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -18,7 +18,7 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
-platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '17.0'
 
 use_modular_headers!
 

--- a/ios/Podfile.properties.json
+++ b/ios/Podfile.properties.json
@@ -1,4 +1,5 @@
 {
+  "ios.deploymentTarget": "17.0",
   "expo.jsEngine": "hermes",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true"
 }

--- a/src/helpers/YouVersionHelper.ts
+++ b/src/helpers/YouVersionHelper.ts
@@ -1,0 +1,24 @@
+import { requireOptionalNativeModule } from "expo";
+
+type YouVersionModule = typeof import("@youversion/platform-react-native");
+
+let cachedModule: YouVersionModule | null | undefined;
+
+export const getYouVersionModule = (): YouVersionModule | null => {
+  if (cachedModule !== undefined) return cachedModule;
+
+  const nativeModule = requireOptionalNativeModule("RNYouVersionPlatform");
+  if (!nativeModule) {
+    cachedModule = null;
+    return cachedModule;
+  }
+
+  try {
+    cachedModule = require("@youversion/platform-react-native") as YouVersionModule;
+  } catch (error) {
+    console.warn("[YouVersion] Failed to load JS module after native module check.", error);
+    cachedModule = null;
+  }
+
+  return cachedModule;
+};


### PR DESCRIPTION
**Previously, we were facing an issue on the Bible screen on mobile where the Native Module was not found. That issue has now been resolved.**

<img width="740" height="828" alt="image" src="https://github.com/user-attachments/assets/fcfe3d58-d28c-47cd-9a0f-c270834bb29b" />

--- 

**Android was also crashing due to a module-related error. Both the iOS and Android issues have now been fixed.**

**Additionally, I updated the minimum deployment target on iOS from 15.1 to 17.0 to resolve the below error.**

<img width="666" height="354" alt="Screenshot 2026-05-08 at 4 42 45 PM" src="https://github.com/user-attachments/assets/19c8eeb0-1331-452a-bf88-303a4b7dd24d" />
